### PR TITLE
Fix syntax and field name

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -113,12 +113,12 @@ interface AssertedDeclaredName {
   attribute IdentifierName name;
   attribute AssertedDeclaredKind kind;
   attribute boolean isCaptured;
-}
+};
 
 interface AssertedBoundName {
   attribute IdentifierName name;
   attribute boolean isCaptured;
-}
+};
 
 interface AssertedBlockScope {
   attribute FrozenArray&lt;AssertedDeclaredName&gt; declaredNames;
@@ -960,7 +960,7 @@ interface LazyFunctionDeclaration : Node {
   attribute boolean isGenerator;
   attribute BindingIdentifier name;
   attribute FrozenArray&lt;Directive&gt; directives;
-  [Lazy] attribute FunctionOrMethodContents content;
+  [Lazy] attribute FunctionOrMethodContents contents;
 };
 
 interface FunctionOrMethodContents : Node {


### PR DESCRIPTION
Added missing semicolons, and also fixed `contents` field name (which is used by other interfaces),
to make diff between binjs-ref's idl cleaner.