### PR TITLE
Remove unnecessary optional from boolean

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -703,8 +703,8 @@ interface LazyFunctionExpression : Node {
 };
 
 interface FunctionExpressionContents : Node {
-  attribute boolean? isFunctionNameCaptured;
-  attribute boolean? isThisCaptured;
+  attribute boolean isFunctionNameCaptured;
+  attribute boolean isThisCaptured;
   attribute AssertedParameterScope parameterScope;
   attribute FormalParameters params;
   attribute AssertedVarScope bodyScope;


### PR DESCRIPTION
I don't see any reason to use optional boolean there,
(and it's not supported by binjs-ref)

Using raw boolean makes implementation simpler.
